### PR TITLE
Made a couple of improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,18 @@ The program uses environment variables to configure the agent to make it easy to
 
 ## General options:
 
-| Environment        | Required | Description                                                                |
-|:-------------------|:---------|:---------------------------------------------------------------------------|
-| `GO_EA_GUID`       | No       | The contents of `config/guid.txt` file that contains the agent identifier. |
-| `GO_EA_SERVER_URL` | Yes      | The base url to the GoCD server.                                           |
+| Environment              | Required | Description                                                                                                              |
+| :----------------------- | :------- | :----------------------------------------------------------------------------------------------------------------------- |
+| `GO_EA_GUID`             | No       | The contents of `config/guid.txt` file that contains the agent identifier.                                               |
+| `GO_EA_SERVER_URL`       | Yes      | The base url to the GoCD server.                                                                                         |
+| `GO_EA_DUMP_ENVIRONMENT` | No       | Whether environment variables should be dumped to the log. Turned off by default for security.                           |
+| `GO_EA_JVM_ARGS`         | No       | JSON formatted list of args that should be passed as JVM args to the agent process. Example: `["-Dfoo=bar", "-Xmx256m"]` |
+| `GO_EA_ROOT_DIR`         | No       | The directory where the gocd agent should execute. Defaults to `/go`.                                                    |
 
 ## Autoregistration options:
 
 | Environment                             | Required | Description                                                                  |
-|:----------------------------------------|:---------|:-----------------------------------------------------------------------------|
+| :-------------------------------------- | :------- | :--------------------------------------------------------------------------- |
 | `GO_EA_AUTO_REGISTER_KEY`               | Yes      | The GoCD agent auto register key.                                            |
 | `GO_EA_AUTO_REGISTER_ENVIRONMENT`       | No       | The name of the environment that the agent should autoregister with.         |
 | `GO_EA_AUTO_REGISTER_ELASTIC_AGENT_ID`  | Yes      | The elastic agent identifier that the agent should autoregister with.        |
@@ -36,10 +39,10 @@ The program uses environment variables to configure the agent to make it easy to
 
 ## SSL options:
 
-| Environment                             | Required | Description                                                                                                  |
-|:----------------------------------------|:---------|:-------------------------------------------------------------------------------------------------------------|
-| `GO_EA_SSL_NO_VERIFY`                   | No       | Whether ssl verification should be turned off. Defaults to `false`.                                           |
-| `GO_EA_SSL_ROOT_CERT_FILE`              | No       | The path to the file containing root CA certificates. Defaults to the file provided by the operating system. |
+| Environment                | Required | Description                                                                                                  |
+| :------------------------- | :------- | :----------------------------------------------------------------------------------------------------------- |
+| `GO_EA_SSL_NO_VERIFY`      | No       | Whether ssl verification should be turned off. Defaults to `false`.                                          |
+| `GO_EA_SSL_ROOT_CERT_FILE` | No       | The path to the file containing root CA certificates. Defaults to the file provided by the operating system. |
 
 ## Building instructions
 

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -5,13 +5,15 @@ import (
 
 	"github.com/ketan/gocd-golang-bootstrapper/agent"
 	"github.com/ketan/gocd-golang-bootstrapper/config"
+	"github.com/ketan/gocd-golang-bootstrapper/env"
 	"github.com/ketan/gocd-golang-bootstrapper/log"
 )
 
-const workingDirectory = "./go"
-
 func main() {
+	workingDirectory := env.GoRootDir()
 	log.Init()
+
+	log.Infof("Executing bootstrapper in %s", workingDirectory)
 
 	err := os.Chdir(workingDirectory)
 	if err != nil {

--- a/log/log.go
+++ b/log/log.go
@@ -25,12 +25,12 @@ func Critical(msg string) {
 
 // Criticalf logs a message using CRITICAL as log level.
 func Criticalf(format string, args ...interface{}) {
-	log.Criticalf(format, args)
+	log.Criticalf(format, args...)
 }
 
 // Debugf logs a message using DEBUG as log level.
 func Debugf(format string, args ...interface{}) {
-	log.Debugf(format, args)
+	log.Debugf(format, args...)
 }
 
 // Info logs a message using INFO as log level.
@@ -40,10 +40,10 @@ func Info(msg string) {
 
 // Infof logs a message using DEBUG as log level.
 func Infof(format string, args ...interface{}) {
-	log.Infof(format, args)
+	log.Infof(format, args...)
 }
 
 // Warningf logs a message using EARNING as log level.
 func Warningf(format string, args ...interface{}) {
-	log.Warningf(format, args)
+	log.Warningf(format, args...)
 }


### PR DESCRIPTION
- Allow optionally dumping environment variables for debugging purposes
- Allow optionally setting the working directory
- Allow optionally setting any additional JVM arguments for the agent

Fix a couple of minor bugs from the previous release.

- logging varargs
- the `GO_EA_SSL_NO_VERIFY` flag was interpreted incorrectly