### PR TITLE
Replace x86 builds with arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=2.3
+VERSION=2.4
 GOFLAGS=
 
 clean:
@@ -9,17 +9,17 @@ goGet:
 
 go-bootstrapper.darwin.amd64: goGet
 	GOOS=darwin GOARCH=amd64 go build $(GOFLAGS) -o out/go-bootstrapper-$(VERSION).darwin.amd64 .
-go-bootstrapper.darwin.386: goGet
-	GOOS=darwin GOARCH=386 go build $(GOFLAGS) -o out/go-bootstrapper-$(VERSION).darwin.386 .
+go-bootstrapper.darwin.arm64: goGet
+	GOOS=darwin GOARCH=arm64 go build $(GOFLAGS) -o out/go-bootstrapper-$(VERSION).darwin.arm64 .
 
 go-bootstrapper.linux.amd64: goGet
 	GOOS=linux GOARCH=amd64 go build $(GOFLAGS) -o out/go-bootstrapper-$(VERSION).linux.amd64 .
-go-bootstrapper.linux.386: goGet
-	GOOS=linux GOARCH=386 go build $(GOFLAGS) -o out/go-bootstrapper-$(VERSION).linux.386 .
+go-bootstrapper.linux.arm64: goGet
+	GOOS=linux GOARCH=arm64 go build $(GOFLAGS) -o out/go-bootstrapper-$(VERSION).linux.arm64 .
 
 go-bootstrapper.windows.amd64: goGet
 	GOOS=windows GOARCH=amd64 go build $(GOFLAGS) -o out/go-bootstrapper-$(VERSION).windows.amd64.exe .
-go-bootstrapper.windows.386: goGet
-	GOOS=windows GOARCH=386 go build $(GOFLAGS) -o out/go-bootstrapper-$(VERSION).windows.386.exe .
+go-bootstrapper.windows.arm64: goGet
+	GOOS=windows GOARCH=arm64 go build $(GOFLAGS) -o out/go-bootstrapper-$(VERSION).windows.arm64.exe .
 
-all: clean go-bootstrapper.darwin.amd64 go-bootstrapper.darwin.386 go-bootstrapper.linux.amd64 go-bootstrapper.linux.386 go-bootstrapper.windows.amd64 go-bootstrapper.windows.386
+all: clean go-bootstrapper.darwin.amd64 go-bootstrapper.darwin.arm64 go-bootstrapper.linux.amd64 go-bootstrapper.linux.arm64 go-bootstrapper.windows.amd64 go-bootstrapper.windows.arm64

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/ketan/gocd-golang-bootstrapper
+
+go 1.19
+
+require github.com/op/go-logging v0.0.0-20160315200505-970db520ece7

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 h1:lDH9UUVJtmYCjyT0CI4q8xvlXPxeZ0gYCVvWbmPlp88=
+github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=


### PR DESCRIPTION
I'm trying to get various multi-arch things working, so would be useful to have this for arm64. It's in use by [the gocd build images](https://github.com/gocd-contrib/gocd-oss-cookbooks/blob/56763737d5a6e7e01a5557871691f2f5d0ef5e35/provision/common.sh#L136-L141).

- built for arm64 on all platforms (can't see a reason to continue building for 386/x86)
- building with modern golang

Seems to be fine with Go 1.19.5 via `make all`.